### PR TITLE
Add a warning when NODE_SECURE_TOKEN is missing

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -41,11 +41,17 @@ defaultScannerCommand("cwd", { strategy: vuln.strategies.NPM_AUDIT })
   .describe(i18n.getToken("cli.commands.cwd.desc"))
   .option("-n, --nolock", i18n.getToken("cli.commands.cwd.option_nolock"), false)
   .option("-f, --full", i18n.getToken("cli.commands.cwd.option_full"), false)
-  .action(commands.scanner.cwd);
+  .action((_, _, opts) => {
+    checkNodeSecureToken();
+    commands.scanner.cwd(opts);
+  });
 
 defaultScannerCommand("from <package>")
   .describe(i18n.getToken("cli.commands.from.desc"))
-  .action(commands.scanner.from);
+  .action((packageName, _, opts) => {
+    checkNodeSecureToken();
+    commands.scanner.from(packageName, opts);
+  });
 
 defaultScannerCommand("auto [package]", { includeOutput: false, strategy: vuln.strategies.SECURITY_WG })
   .describe(i18n.getToken("cli.commands.auto.desc"))
@@ -62,7 +68,10 @@ prog
   .command("verify [package]")
   .describe(i18n.getToken("cli.commands.verify.desc"))
   .option("-j, --json", i18n.getToken("cli.commands.verify.option_json"), false)
-  .action(commands.verify.main);
+  .action((packageName, _, opts) => {
+    checkNodeSecureToken();
+    commands.verify.main(packageName, opts);
+  });
 
 prog
   .command("summary [json]")
@@ -101,4 +110,10 @@ function defaultScannerCommand(name, options = {}) {
   }
 
   return cmd;
+}
+
+function checkNodeSecureToken(){
+  if(process.env.NODE_SECURE_TOKEN){
+    kleur.yellow("Environment variable \"NODE_SECURE_TOKEN\" is missing: You need to login to npm with \`$ npm login\`")
+  }
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -43,24 +43,14 @@ defaultScannerCommand("cwd", { strategy: vuln.strategies.NPM_AUDIT })
   .option("-f, --full", i18n.getToken("cli.commands.cwd.option_full"), false)
   .action(async(_, __, opts) => {
     checkNodeSecureToken();
-    try {
-      await commands.scanner.cwd(opts);
-    }
-    catch (err) {
-      // DO NOTHING
-    }
+    await commands.scanner.cwd(opts);
   });
 
 defaultScannerCommand("from <package>")
   .describe(i18n.getToken("cli.commands.from.desc"))
   .action(async(packageName, _, opts) => {
     checkNodeSecureToken();
-    try {
-      await commands.scanner.from(packageName, opts);
-    }
-    catch (err) {
-      // DO NOTHING
-    }
+    await commands.scanner.from(packageName, opts);
   });
 
 defaultScannerCommand("auto [package]", { includeOutput: false, strategy: vuln.strategies.SECURITY_WG })
@@ -79,13 +69,8 @@ prog
   .describe(i18n.getToken("cli.commands.verify.desc"))
   .option("-j, --json", i18n.getToken("cli.commands.verify.option_json"), false)
   .action(async(packageName, _, opts) => {
-    try {
-      checkNodeSecureToken();
-      await commands.verify.main(packageName, opts);
-    }
-    catch (err) {
-      // DO NOTHING
-    }
+    checkNodeSecureToken();
+    await commands.verify.main(packageName, opts);
   });
 
 prog
@@ -130,13 +115,9 @@ function defaultScannerCommand(name, options = {}) {
 function checkNodeSecureToken() {
   if (!process.env.NODE_SECURE_TOKEN) {
     console.log(
-      kleur
-        .white()
-        .bold(
-          `\n ${kleur
-            .yellow()
-            .bold(`Environment variable ${"\"NODE_SECURE_TOKEN\""} is missing.`)}`
-        )
+      kleur.white().bold(
+        `\n ${kleur.yellow().bold(`Environment variable ${"\"NODE_SECURE_TOKEN\""} is missing.`)}`
+      )
     );
   }
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -6,6 +6,7 @@ dotenv.config();
 import { createRequire } from "module";
 
 // Import Third-party Dependencies
+import { execSync } from "node:child_process";
 import kleur from "kleur";
 import sade from "sade";
 import semver from "semver";
@@ -41,16 +42,26 @@ defaultScannerCommand("cwd", { strategy: vuln.strategies.NPM_AUDIT })
   .describe(i18n.getToken("cli.commands.cwd.desc"))
   .option("-n, --nolock", i18n.getToken("cli.commands.cwd.option_nolock"), false)
   .option("-f, --full", i18n.getToken("cli.commands.cwd.option_full"), false)
-  .action((_, _, opts) => {
+  .action(async(_, __, opts) => {
     checkNodeSecureToken();
-    commands.scanner.cwd(opts);
+    try {
+      await commands.scanner.cwd(opts);
+    }
+    catch (err) {
+      // DO NOTHING
+    }
   });
 
 defaultScannerCommand("from <package>")
   .describe(i18n.getToken("cli.commands.from.desc"))
-  .action((packageName, _, opts) => {
+  .action(async(packageName, _, opts) => {
     checkNodeSecureToken();
-    commands.scanner.from(packageName, opts);
+    try {
+      await commands.scanner.from(packageName, opts);
+    }
+    catch (err) {
+      // DO NOTHING
+    }
   });
 
 defaultScannerCommand("auto [package]", { includeOutput: false, strategy: vuln.strategies.SECURITY_WG })
@@ -68,9 +79,14 @@ prog
   .command("verify [package]")
   .describe(i18n.getToken("cli.commands.verify.desc"))
   .option("-j, --json", i18n.getToken("cli.commands.verify.option_json"), false)
-  .action((packageName, _, opts) => {
-    checkNodeSecureToken();
-    commands.verify.main(packageName, opts);
+  .action(async(packageName, _, opts) => {
+    try {
+      checkNodeSecureToken();
+      await commands.verify.main(packageName, opts);
+    }
+    catch (err) {
+      // DO NOTHING
+    }
   });
 
 prog
@@ -112,8 +128,17 @@ function defaultScannerCommand(name, options = {}) {
   return cmd;
 }
 
-function checkNodeSecureToken(){
-  if(process.env.NODE_SECURE_TOKEN){
-    kleur.yellow("Environment variable \"NODE_SECURE_TOKEN\" is missing: You need to login to npm with \`$ npm login\`")
+function checkNodeSecureToken() {
+  if (!process.env.NODE_SECURE_TOKEN) {
+    console.log(
+      kleur
+        .white()
+        .bold(
+          `\n ${kleur
+            .yellow()
+            .bold(`Environment variable ${"\"NODE_SECURE_TOKEN\""} is missing.
+            \trun${"`npm login`"} to login`)}`
+        )
+    );
   }
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -6,7 +6,6 @@ dotenv.config();
 import { createRequire } from "module";
 
 // Import Third-party Dependencies
-import { execSync } from "node:child_process";
 import kleur from "kleur";
 import sade from "sade";
 import semver from "semver";
@@ -136,8 +135,7 @@ function checkNodeSecureToken() {
         .bold(
           `\n ${kleur
             .yellow()
-            .bold(`Environment variable ${"\"NODE_SECURE_TOKEN\""} is missing.
-            \trun${"`npm login`"} to login`)}`
+            .bold(`Environment variable ${"\"NODE_SECURE_TOKEN\""} is missing.`)}`
         )
     );
   }

--- a/test/commands/summary.spec.js
+++ b/test/commands/summary.spec.js
@@ -1,11 +1,15 @@
 // Import Node.js Dependencies
-import { spawn } from "child_process";
+import dotenv from "dotenv";
+import { spawn, execSync } from "child_process";
 import { fileURLToPath } from "url";
 import path from "path";
+
+dotenv.config();
 
 // Import Third-party Dependencies
 import test from "tape";
 import splitByLine from "split2";
+import kleur from "kleur";
 
 // CONSTANTS
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -42,6 +46,14 @@ test("summary should execute summary command on fixtures 'result-test1.json'", a
 
     tape.ok(regexp, "we are expecting this line");
     tape.ok(regexp.test(line), `line matches ${regexp}`);
+  }
+
+  tape.end();
+});
+
+test("warning on missing 'NODE_SECURE_TOKEN'", async(tape) => {
+  if (!process.env.NODE_SECURE_TOKEN) {
+    tape.equal(process.env.NODE_SECURE_TOKEN, undefined);
   }
 
   tape.end();

--- a/test/commands/summary.spec.js
+++ b/test/commands/summary.spec.js
@@ -1,6 +1,6 @@
 // Import Node.js Dependencies
 import dotenv from "dotenv";
-import { spawn, execSync } from "child_process";
+import { spawn } from "child_process";
 import { fileURLToPath } from "url";
 import path from "path";
 
@@ -9,7 +9,6 @@ dotenv.config();
 // Import Third-party Dependencies
 import test from "tape";
 import splitByLine from "split2";
-import kleur from "kleur";
 
 // CONSTANTS
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -46,14 +45,6 @@ test("summary should execute summary command on fixtures 'result-test1.json'", a
 
     tape.ok(regexp, "we are expecting this line");
     tape.ok(regexp.test(line), `line matches ${regexp}`);
-  }
-
-  tape.end();
-});
-
-test("warning on missing 'NODE_SECURE_TOKEN'", async(tape) => {
-  if (!process.env.NODE_SECURE_TOKEN) {
-    tape.equal(process.env.NODE_SECURE_TOKEN, undefined);
   }
 
   tape.end();


### PR DESCRIPTION
I added a warning message on_commands("cwd | from | verify") by checking the environment variable NODE_SECURE_TOKEN