### PR TITLE
fix: use info as default instead of overview

### DIFF
--- a/public/js/components/package.info.js
+++ b/public/js/components/package.info.js
@@ -110,7 +110,7 @@ export class PackageInfo {
   }
 
   enableNavigation(name) {
-    const div = this.menus.get(name);
+    const div = this.menus.has(name) ? this.menus.get(name) : this.menus.get("info");
 
     const isActive = div.classList.contains("active");
     const isDisabled = div.classList.contains("disabled");

--- a/public/js/components/settings.js
+++ b/public/js/components/settings.js
@@ -2,6 +2,8 @@
 import { getJSON } from "@nodesecure/vis-network";
 
 export class Settings {
+  static defaultMenuName = "info";
+
   constructor() {
     this.saveEnabled = false;
     this.dom = {
@@ -49,7 +51,7 @@ export class Settings {
     }
 
     const newConfig = {
-      defaultPackageMenu: this.dom.defaultPackageMenu.value,
+      defaultPackageMenu: this.dom.defaultPackageMenu.value || Settings.defaultMenuName,
       ignore: { flags: [], warnings: [] }
     };
 

--- a/src/http-server/config.js
+++ b/src/http-server/config.js
@@ -17,7 +17,7 @@ export async function get() {
   }
   catch (error) {
     const defaultValue = {
-      defaultPackageMenu: "overview",
+      defaultPackageMenu: "info",
       ignore: { flags: [], warnings: [] }
     };
 


### PR DESCRIPTION
Fixing a bug with cached settings and default package menu to open. That fix make impossible for the left menu to not open when there is a cache mismatch.