### PR TITLE
fix: remove import protocol for doc redirection

### DIFF
--- a/public/js/components/package.info.js
+++ b/public/js/components/package.info.js
@@ -211,11 +211,9 @@ export class PackageInfo {
     utils.createItemsList(clone.getElementById("nodedep"), composition.required_nodejs, {
       hideItemsLength: 8,
       onclick: (event, coreLib) => {
-        function formatNodeLib(lib) {
-          return lib.startsWith('node:') ? lib.slice(5) : lib;
-        }
+        const lib = coreLib.startsWith('node:') ? coreLib.slice(5) : coreLib;
 
-        window.open(`https://nodejs.org/dist/latest/docs/api/${formatNodeLib(coreLib)}.html`, "_blank").focus();
+        window.open(`https://nodejs.org/dist/latest/docs/api/${lib}.html`, "_blank").focus();
       }
     });
 

--- a/public/js/components/package.info.js
+++ b/public/js/components/package.info.js
@@ -211,7 +211,11 @@ export class PackageInfo {
     utils.createItemsList(clone.getElementById("nodedep"), composition.required_nodejs, {
       hideItemsLength: 8,
       onclick: (event, coreLib) => {
-        window.open(`https://nodejs.org/dist/latest/docs/api/${coreLib}.html`, "_blank").focus();
+        function formatNodeLib(lib) {
+          return lib.startsWith('node:') ? lib.slice(5) : lib;
+        }
+
+        window.open(`https://nodejs.org/dist/latest/docs/api/${formatNodeLib(coreLib)}.html`, "_blank").focus();
       }
     });
 
@@ -521,7 +525,7 @@ export class PackageInfo {
             childs: [
               utils.createDOMElement("p", {
                 className: "title",
-                text: `incrimined value`
+                text: "incrimined value"
               }),
               utils.createDOMElement("p", {
                 className: "value",


### PR DESCRIPTION
If the librairies use Node.js procotol imports, it will redirect to 404.
For instance: https://nodejs.org/dist/latest/docs/api/node:path.html instead of https://nodejs.org/dist/latest/docs/api/path.html