### PR TITLE
feat: apply settings on save

### DIFF
--- a/public/js/components/settings.js
+++ b/public/js/components/settings.js
@@ -76,6 +76,8 @@ export class Settings {
     });
     this.config = newConfig;
     this.saveButton.classList.add("disabled");
+
+    window.dispatchEvent(new CustomEvent("settings-saved", { detail: this.config }));
   }
 
   updateSettings() {

--- a/workspaces/vis-network/src/dataset.js
+++ b/workspaces/vis-network/src/dataset.js
@@ -59,6 +59,9 @@ export default class NodeSecureDataSet extends EventTarget {
     const dataEntries = Object.entries(data.dependencies);
     this.dependenciesCount = dataEntries.length;
 
+    this.rawEdgesData = [];
+    this.rawNodesData = [];
+
     for (const [packageName, descriptor] of dataEntries) {
       for (const [currVersion, opt] of Object.entries(descriptor.versions)) {
         const { id, usedBy, flags, size, license, author, composition, warnings } = opt;

--- a/workspaces/vis-network/src/network.js
+++ b/workspaces/vis-network/src/network.js
@@ -93,6 +93,7 @@ export default class NodeSecureNetwork {
       this.isLoaded = true;
       this.network.stopSimulation();
       this.network.on("click", this.neighbourHighlight.bind(this));
+      this.network.setOptions({ physics: false });
     });
 
     this.network.stabilize(500);


### PR DESCRIPTION
Fixes #221 

Also note `this.network.setOptions({ physics: false });`: this disable physics after initialization so now when we drag & move a node, the others one stay in place (it's much better and allow to move nodes as we want).