### PR TITLE
fix: update cache when scanning via cli

### DIFF
--- a/public/components/views/search/search.css
+++ b/public/components/views/search/search.css
@@ -234,6 +234,8 @@ input:-webkit-autofill {
   border: 1px solid #54688424;
   padding: 10px;
   border-radius: 4px;
+  max-height: calc(100vh - 380px);
+  overflow: auto;
 }
 
 .cache-packages h1 {

--- a/src/commands/scanner.js
+++ b/src/commands/scanner.js
@@ -13,6 +13,7 @@ import * as Scanner from "@nodesecure/scanner";
 
 // Import Internal Dependencies
 import * as http from "./http.js";
+import { appCache } from "../http-server/cache.js";
 
 export async function auto(spec, options) {
   const { keep, ...commandOptions } = options;
@@ -59,7 +60,7 @@ export async function cwd(options) {
     initLogger(void 0, !silent)
   );
 
-  return logAndWrite(payload, output);
+  return await logAndWrite(payload, output);
 }
 
 export async function from(spec, options) {
@@ -71,7 +72,7 @@ export async function from(spec, options) {
     initLogger(spec, !silent)
   );
 
-  return logAndWrite(payload, output);
+  return await logAndWrite(payload, output);
 }
 
 function initLogger(spec, verbose = true) {
@@ -153,7 +154,7 @@ function initLogger(spec, verbose = true) {
   return logger;
 }
 
-function logAndWrite(payload, output = "nsecure-result") {
+async function logAndWrite(payload, output = "nsecure-result") {
   if (payload === null) {
     console.log(i18n.getTokenSync("cli.no_dep_to_proceed"));
 
@@ -178,6 +179,8 @@ function logAndWrite(payload, output = "nsecure-result") {
   console.log("");
   console.log(kleur.white().bold(i18n.getTokenSync("cli.successfully_written_json", kleur.green().bold(filePath))));
   console.log("");
+
+  await appCache.setRootPayload(payload, { logging: false });
 
   return filePath;
 }

--- a/src/http-server/endpoints/data.js
+++ b/src/http-server/endpoints/data.js
@@ -18,8 +18,7 @@ export async function get(_req, res) {
     logger.info(`[data|get](current: ${current})`);
     logger.debug(`[data|get](lru: ${lru})`);
 
-    const formatted = current.replaceAll("/", "-");
-    send(res, 200, await appCache.getPayload(formatted));
+    send(res, 200, await appCache.getPayload(current));
   }
   catch {
     logger.error(`[data|get](No cache yet. Creating one...)`);
@@ -39,7 +38,7 @@ export async function get(_req, res) {
     logger.info(`[data|get](dep: ${formatted}|version: ${version}|rootDependencyName: ${payload.rootDependencyName})`);
 
     await appCache.updatePayloadsList(payloadsList);
-    appCache.updatePayload(formatted.replaceAll("/", "-"), payload);
+    appCache.updatePayload(formatted, payload);
     logger.info(`[data|get](cache: created|payloadsList: ${payloadsList.lru})`);
 
     send(res, 200, payload);

--- a/src/http-server/websocket/remove.js
+++ b/src/http-server/websocket/remove.js
@@ -74,7 +74,7 @@ export async function remove(ws, pkg) {
       }));
     }
 
-    appCache.removePayload(formattedPkg.replaceAll("/", "-"));
+    appCache.removePayload(formattedPkg);
   }
   catch (error) {
     logger.error(`[ws|remove](error: ${error.message})`);

--- a/src/http-server/websocket/search.js
+++ b/src/http-server/websocket/search.js
@@ -59,7 +59,7 @@ export async function search(ws, pkg) {
     // update the payloads list
     const { lru, older, lastUsed, root } = await appCache.removeLastLRU();
     lru.push(pkg);
-    appCache.updatePayload(pkg.replaceAll("/", "-"), payload);
+    appCache.updatePayload(pkg, payload);
     const updatedList = {
       lru: [...new Set(lru)],
       older,


### PR DESCRIPTION
Update the cache when scanning a package via `nsecure from` or `nsecure cwd` (`cwd` will be improved in #442).

This PR also fixes the cache initialization: available payloads were saved in `list` instead of `older`, and the interface now correctly shows every package available (the `Packages available in the cache` section in the search page).