### PR TITLE
Replace strip-ansi with Node.js native util.stripVTControlCharacters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nodesecure/cli",
+  "name": "@nodesecure/cli",strip-ansi
   "version": "3.1.0",
   "description": "Node.js security CLI",
   "main": "./bin/index.js",
@@ -77,8 +77,7 @@
     "pkg-ok": "^3.0.0",
     "pretty-bytes": "^7.0.0",
     "rimraf": "^6.0.1",
-    "server-destroy": "^1.0.1",
-    "strip-ansi": "^7.1.0"
+    "server-destroy": "^1.0.1"
   },
   "dependencies": {
     "@nodesecure/documentation-ui": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nodesecure/cli",strip-ansi
+  "name": "@nodesecure/cli",
   "version": "3.1.0",
   "description": "Node.js security CLI",
   "main": "./bin/index.js",

--- a/test/commands/summary.test.js
+++ b/test/commands/summary.test.js
@@ -5,9 +5,9 @@ dotenv.config();
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { describe, it } from "node:test";
+import { stripVTControlCharacters } from "node:util";
 
 // Import Third-party Dependencies
-import stripAnsi from "strip-ansi";
 import * as i18n from "@nodesecure/i18n";
 
 // Import Internal Dependencies
@@ -47,7 +47,7 @@ describe("CLI Commands: summary", () => {
     for await (const line of runProcess(processOptions)) {
       const regexp = lines.shift();
       t.assert.ok(regexp, "we are expecting this line");
-      t.assert.ok(regexp.test(stripAnsi(line)), `line (${line}) matches ${regexp}`);
+      t.assert.ok(regexp.test(stripVTControlCharacters(line)), `line (${line}) matches ${regexp}`);
     }
   });
 
@@ -66,7 +66,7 @@ describe("CLI Commands: summary", () => {
 
     for await (const line of runProcess(processOptions)) {
       const expectedLineRegex = expectedLines.shift();
-      const formattedLine = stripAnsi(line);
+      const formattedLine = stripVTControlCharacters(line);
       t.assert.ok(expectedLineRegex, "we are expecting this line");
       t.assert.ok(expectedLineRegex.test(formattedLine), `line (${formattedLine}) should match ${expectedLineRegex}`);
     }

--- a/test/helpers/cliCommandRunner.js
+++ b/test/helpers/cliCommandRunner.js
@@ -1,10 +1,10 @@
 // Import Node.js Dependencies
 import { fork } from "node:child_process";
 import { createInterface } from "node:readline";
+import { stripVTControlCharacters } from "node:util";
 
 // Import Third-party Dependencies
 import { MockAgent, setGlobalDispatcher } from "undici";
-import stripAnsi from "strip-ansi";
 
 export async function* runProcess(options) {
   const { path, args = [], cwd = process.cwd(), undiciMockAgentOptions = null } = options;
@@ -20,7 +20,7 @@ export async function* runProcess(options) {
     const rStream = createInterface(childProcess.stdout);
 
     for await (const line of rStream) {
-      yield stripAnsi(line);
+      yield stripVTControlCharacters(line);
     }
   }
   finally {


### PR DESCRIPTION
Closes #485 

This PR replaces the external strip-ansi dependency with the native Node.js method util.stripVTControlCharacters.

Changes :
- Removed strip-ansi from dependencies
- Updated summary.test.js to use util.stripVTControlCharacters
- Updated cliCommandRunner implementation to rely on the native method

Test :
All tests passed locally using npm run test.