### PR TITLE
fix(vis-network): unit tests

### DIFF
--- a/workspaces/vis-network/test/dataset-payload.json
+++ b/workspaces/vis-network/test/dataset-payload.json
@@ -1,6 +1,6 @@
 {
   "id": "abcde",
-  "rootDepencyName": "pkg1",
+  "rootDependencyName": "pkg1",
   "highlighted": {
     "contacts": [
       {
@@ -34,6 +34,13 @@
   },
   "dependencies": {
     "pkg2": {
+       "metadata": {
+        "author": {
+          "name": "john papa"
+        },
+        "maintainers": [],
+         "publishers": []
+      },
       "versions": {
         "1.0.3": {
           "usedBy": {
@@ -51,17 +58,24 @@
               ".json"
             ]
           },
-          "license": {
-            "uniqueLicenseIds": [
-              "Unlicense"
-            ]
-          },
+          
+          "uniqueLicenseIds": [
+            "Unlicense"
+          ],
+          
           "name": "pkg2",
           "version": "1.0.3"
         }
       }
     },
     "pkg3": {
+       "metadata": {
+        "author": {
+          "name": "john wick"
+        },
+        "maintainers": [],
+         "publishers": []
+      },
       "versions": {
         "3.4.0": {
           "id": 4,
@@ -85,15 +99,21 @@
               ".json"
             ]
           },
-          "license": {
-            "uniqueLicenseIds": [
-              "Licence1"
-            ]
-          }
+          "uniqueLicenseIds": [
+            "Licence1"
+          ]
+          
         }
       }
     },
     "pkg1": {
+      "metadata": {
+        "author": {
+          "name": "john doe"
+        },
+        "maintainers": [],
+         "publishers": []
+      },
       "versions": {
         "3.0.0": {
           "id": 0,
@@ -115,6 +135,8 @@
             ]
           },
           "license": "a string licence (should be unknown)",
+           "uniqueLicenseIds": [
+          ],
           "warnings": []
         }
       }

--- a/workspaces/vis-network/test/dataset.test.js
+++ b/workspaces/vis-network/test/dataset.test.js
@@ -8,6 +8,16 @@ import { getDataSetPayload } from "./dataset.fixture.js";
 
 const dataSetPayload = await getDataSetPayload();
 
+global.window = {
+  settings: {
+    config: {
+      showFriendlyDependencies: true
+
+    }
+
+  }
+}
+
 test("NodeSecureDataSet.init with given payload", async() => {
   const nsDataSet = new NodeSecureDataSet();
   await nsDataSet.init(dataSetPayload);
@@ -57,21 +67,17 @@ test("NodeSecureDataSet.isHighlighted", async() => {
 
 test("NodeSecureDataSet.computeLicenses", () => {
   const nsDataSet = new NodeSecureDataSet();
-  nsDataSet.computeLicense("MIT");
-  assert.equal(Object.keys(nsDataSet.licenses).length, 1, "should have 1 license");
-  assert.equal(nsDataSet.licenses.Unknown, 1, "should have 1 unknown license");
-
-  nsDataSet.computeLicense({ uniqueLicenseIds: ["MIT", "MIT", "RND"] });
+  nsDataSet.computeLicense(["MIT", "MIT", "RND"] );
   assert.equal(Object.keys(nsDataSet.licenses).length, 3, "should have 3 licenses (MIT, RND & 1 unknown)");
   assert.equal(nsDataSet.licenses.MIT, 2, "should have 2 MIT licenses");
 });
 
 test("NodeSecureDataSet.computeAuthors", () => {
   const nsDataSet = new NodeSecureDataSet();
-  nsDataSet.computeAuthor({ name: "John Doe" });
+  nsDataSet.computeAuthor({ name: "John Doe" }, "pkg@1.1");
   assert.equal(nsDataSet.authors.get("John Doe").packages.size, 1, "should have 1 author: John Doe");
 
-  nsDataSet.computeAuthor({ name: "John Doe" });
+  nsDataSet.computeAuthor({ name: "John Doe" }, "pkg@1.2");
 
   assert.equal(nsDataSet.authors.size, 1, "should have 1 author: John Doe (after the 2nd contribution");
   assert.equal(nsDataSet.authors.get("John Doe").packages.size, 2, "should have 1 author: John Doe (2nd time)");


### PR DESCRIPTION
Adapt unit tests and fixture to current implementation of dataset.

i need advice on unknown license computation, i removed their test because current algorithm does handle this case, for example :
-`  "license": "a string licence (should be unknown)" ` 
-  will not give `{unknown: 1}`
- because computeLicense fn expects an iterable and a string is an iterable so the number of licenses will be the number of characters.

does unknown license is buggy or not handled anymore ?  