### PR TITLE
refactor: replace dotenv with native Node.js process.loadEnvFile

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
-import dotenv from "dotenv";
-dotenv.config({ quiet: true });
+
+// Load .env file if it exists (quiet - no error if missing)
+try {
+  process.loadEnvFile();
+}
+catch {
+  // .env file not found or not readable - ignore silently
+}
 
 // Import Node.js Dependencies
 import path from "node:path";

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "@topcli/pretty-json": "^1.0.0",
     "@topcli/prompts": "^2.0.0",
     "@topcli/spinner": "^4.0.0",
-    "dotenv": "^17.0.0",
     "filenamify": "^7.0.0",
     "highlightjs-line-numbers.js": "^2.8.0",
     "ini": "^6.0.0",

--- a/test/commands/cache.test.js
+++ b/test/commands/cache.test.js
@@ -1,5 +1,10 @@
-import dotenv from "dotenv";
-dotenv.config({ quiet: true });
+// Load .env file if it exists (quiet - no error if missing)
+try {
+  process.loadEnvFile();
+}
+catch {
+  // .env file not found or not readable - ignore silently
+}
 
 // Import Node.js Dependencies
 import fs from "node:fs";

--- a/test/commands/summary.test.js
+++ b/test/commands/summary.test.js
@@ -1,5 +1,10 @@
-import dotenv from "dotenv";
-dotenv.config({ quiet: true });
+// Load .env file if it exists (quiet - no error if missing)
+try {
+  process.loadEnvFile();
+}
+catch {
+  // .env file not found or not readable - ignore silently
+}
 
 // Import Node.js Dependencies
 import { fileURLToPath } from "node:url";

--- a/test/commands/verify.test.js
+++ b/test/commands/verify.test.js
@@ -1,5 +1,10 @@
-import dotenv from "dotenv";
-dotenv.config({ quiet: true });
+// Load .env file if it exists (quiet - no error if missing)
+try {
+  process.loadEnvFile();
+}
+catch {
+  // .env file not found or not readable - ignore silently
+}
 
 // Import Node.js Dependencies
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
## Summary
- Replace `dotenv.config({ quiet: true })` with native `process.loadEnvFile()`
- Use try/catch to silently ignore missing `.env` files
- Remove `dotenv` dependency from package.json

Closes #636