### PR TITLE
fix: color execution time based on duration in verbose mode (#680)

### DIFF
--- a/src/commands/scanner.js
+++ b/src/commands/scanner.js
@@ -258,6 +258,7 @@ function colorExecutionTime(timeMs) {
   else if (timeMs <= 30_000) {
     return kleur.yellow().bold(formatted);
   }
+
   return kleur.red().bold(formatted);
 }
 


### PR DESCRIPTION
## Summary

In verbose mode, execution time was always displayed in cyan (blue). This PR introduces a color palette to make it easier to spot slow operations.

Fixes #680

## Problem

When running in verbose mode, all execution times are displayed in the same cyan color regardless of how long they take, making it hard to quickly identify slow operations.

## Solution

Added a `colorExecutionTime()` helper function that returns the formatted time string with a color based on the duration:

- ≤1s: green (fast)
- 1-5s: cyan (normal)
- 5-30s: yellow (slow)
- ≥30s: red (very slow)

## Changes

- `src/commands/scanner.js`: Added `colorExecutionTime()` function and applied it to the verbose stat output